### PR TITLE
Fixed bug: now selects first favorite item, on arrow key switch

### DIFF
--- a/ClipView.cpp
+++ b/ClipView.cpp
@@ -161,8 +161,6 @@ ClipView::KeyDown(const char* bytes, int32 numBytes)
 		case B_RIGHT_ARROW:
 		{
 			if (my_app->fMainWindow->Lock())
-				if (my_app->fMainWindow->fFavorites->CurrentSelection() < 0)
-					my_app->fMainWindow->fFavorites->Select(0);
 				my_app->fMainWindow->fFavorites->MakeFocus(true);
 			my_app->fMainWindow->Unlock();
 			break;

--- a/ClipView.cpp
+++ b/ClipView.cpp
@@ -161,6 +161,8 @@ ClipView::KeyDown(const char* bytes, int32 numBytes)
 		case B_RIGHT_ARROW:
 		{
 			if (my_app->fMainWindow->Lock())
+				if (my_app->fMainWindow->fFavorites->CountItems() == 1)
+					my_app->fMainWindow->fFavorites->Select(0);
 				my_app->fMainWindow->fFavorites->MakeFocus(true);
 			my_app->fMainWindow->Unlock();
 			break;

--- a/ClipView.cpp
+++ b/ClipView.cpp
@@ -161,7 +161,7 @@ ClipView::KeyDown(const char* bytes, int32 numBytes)
 		case B_RIGHT_ARROW:
 		{
 			if (my_app->fMainWindow->Lock())
-				if (my_app->fMainWindow->fFavorites->CountItems() == 1)
+				if (my_app->fMainWindow->fFavorites->CurrentSelection() < 0)
 					my_app->fMainWindow->fFavorites->Select(0);
 				my_app->fMainWindow->fFavorites->MakeFocus(true);
 			my_app->fMainWindow->Unlock();

--- a/FavView.cpp
+++ b/FavView.cpp
@@ -112,11 +112,10 @@ FavView::MakeFocus(bool focused)
 {
 	BListView::MakeFocus(focused);
 
-	
 	if (focused) {
 		// only signal FavView is focused when gaining focus
 		my_app->fMainWindow->SetHistoryActiveFlag(!focused);
-		
+
 		// When gaining focus and no items selected, select the first item.
 		if (CurrentSelection() < 0)
 			Select(0);

--- a/FavView.cpp
+++ b/FavView.cpp
@@ -115,6 +115,11 @@ FavView::MakeFocus(bool focused)
 	// only signal FavView is focused when gaining focus
 	if (focused)
 		my_app->fMainWindow->SetHistoryActiveFlag(!focused);
+	
+	if (focused){
+		if (BListView::CurrentSelection() < 0)
+			BListView::Select(0);
+	}
 
 }
 

--- a/FavView.cpp
+++ b/FavView.cpp
@@ -112,13 +112,14 @@ FavView::MakeFocus(bool focused)
 {
 	BListView::MakeFocus(focused);
 
-	// only signal FavView is focused when gaining focus
-	if (focused)
-		my_app->fMainWindow->SetHistoryActiveFlag(!focused);
 	
-	if (focused){
-		if (BListView::CurrentSelection() < 0)
-			BListView::Select(0);
+	if (focused) {
+		// only signal FavView is focused when gaining focus
+		my_app->fMainWindow->SetHistoryActiveFlag(!focused);
+		
+		// When gaining focus and no items selected, select the first item.
+		if (CurrentSelection() < 0)
+			Select(0);
 	}
 
 }


### PR DESCRIPTION
Fixes #23 
Replicated and fixed. Switching between the favorite list and clips list is more consistent now.